### PR TITLE
Add if-exists check for the rating field

### DIFF
--- a/src/filter.py
+++ b/src/filter.py
@@ -19,6 +19,9 @@ def suggest(query):
 
 
 def get_stars(product):
+    hasRating = 'rating' in product
+    if not hasRating:
+        return
     rating = float(product['rating']['averageRating'])
     rounded = int(round(rating))
     return string.replace('☆☆☆☆☆', '☆', '★', maxreplace=rounded)
@@ -41,10 +44,10 @@ def add_product_item(product):
         float(product['lowestPrice']['amount']),
         product['lowestPrice']['currency'],
         locale=get_locale()))
-    subtitle = '{} – {} – {}'.format(
-            cheapest_price,
-            utf8ify(product['categoryName']),
-            get_stars(product))
+    subtitle = ' - '.join(filter(None, (
+        cheapest_price,
+        utf8ify(product['categoryName']),
+        get_stars(product))))
     largetext = '{} – {}'.format(title, cheapest_price)
     wf.add_item(
         title=title,


### PR DESCRIPTION
Seems like the `rating` field for a `product` has been removed in their API. This should take care of it without removing support for it, so that the rating is still showed _if_ the field is present.

Might be easier to just remove support for it all together though : )